### PR TITLE
unset client tag when subscribe to non ext topic

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -617,6 +617,13 @@ func (c *ClientV2) SetMsgTimeout(msgTimeout int) error {
 	return nil
 }
 
+
+func (c *ClientV2) UnsetDesiredTag() {
+	c.LockWrite()
+	defer c.UnlockWrite()
+	c.DesiredTag = ""
+}
+
 func (c *ClientV2) SetDesiredTag(tagStr string) error {
 	if tagStr == "" {
 		return nil

--- a/nsqdserver/protocol_v2.go
+++ b/nsqdserver/protocol_v2.go
@@ -941,9 +941,10 @@ func (p *protocolV2) internalSUB(client *nsqd.ClientV2, params [][]byte, enableT
 		return nil, protocol.NewFatalClientErr(nil, FailedOnNotLeader, "")
 	}
 	channel := topic.GetChannel(channelName)
+	// client with tag is subscribe to topic not support tag, remove client's tag and treat it like untaged consumer
 	if !topic.IsExt() && client.GetDesiredTag() != "" {
-		return nil, protocol.NewFatalClientErr(nil, ext.E_EXT_NOT_SUPPORT,
-			fmt.Sprintf("IDENTIFY before subscribe has a tag %v to topic %v not support tag.", client.GetDesiredTag(), topicName))
+		nsqd.NsqLogger().Logf("[%v] IDENTIFY before subscribe has a tag %v to topic %v not support tag. Remove client's tag.", client, client.GetDesiredTag(), topicName)
+		client.UnsetDesiredTag()
 	}
 
 	err = channel.AddClient(client.ID, client)


### PR DESCRIPTION
Unset client(consumer) tag fetched in IDENTIFY and consume message as normal consumer, if current topic does not has extend support.
Signed-off-by: 元守 <lulin@youzan.com>